### PR TITLE
Minor CSS / accesibility tweaks

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1,25 +1,30 @@
+@import './reset.css';
 @import '@xterm/xterm/css/xterm.css';
 
-body {
-    margin: 0;
-    overflow: hidden;
-    color: white;
+html, body, .glasgow-app {
+    height: 100%;
     background: black;
+    color: white;
 }
 
 a {
     color: lightblue;
 }
 
-#bar {
-    padding: 12px 20px;
+#terminal {
+    height: 100%;
 }
 
-#terminal {
-    font-family: monospace;
-    font-size: 20px;
-    position: absolute;
-    width: 100%;
-    top: 50px;
-    bottom: 0px;
+.glasgow-app {
+    display: flex;
+    flex-direction: column;
+}
+
+.glasgow-terminal {
+    flex: 1;
+    overflow: hidden;
+}
+
+.glasgow-bar {
+    padding: 12px 20px;
 }

--- a/src/app.css
+++ b/src/app.css
@@ -1,14 +1,21 @@
 @import './reset.css';
 @import '@xterm/xterm/css/xterm.css';
 
-html, body, .glasgow-app {
-    height: 100%;
+:root {
     background: black;
     color: white;
+    font-family: sans-serif;
 }
 
-a {
-    color: lightblue;
+html, body, .glasgow-app {
+    height: 100%;
+}
+
+code {
+    font-family: monospace;
+    background-color: #444;
+    padding: 2px;
+    border-radius: 4px;
 }
 
 #terminal {
@@ -26,9 +33,32 @@ a {
 }
 
 .glasgow-bar {
+    color: #ddd;
+    background: #222;
     padding: 12px 20px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    column-gap: 12px;
+}
+
+.glasgow-bar p {
+    flex: 1;
+}
+
+.glasgow-controls button {
+    width: max-content;
 }
 
 .xterm-screen {
     padding: 12px;
+}
+
+@media (width < 640px) {
+    .glasgow-bar {
+        flex-direction: column;
+        align-items: normal;
+        column-gap: 0;
+        row-gap: 12px;
+    }
 }

--- a/src/app.css
+++ b/src/app.css
@@ -28,3 +28,7 @@ a {
 .glasgow-bar {
     padding: 12px 20px;
 }
+
+.xterm-screen {
+    padding: 12px;
+}

--- a/src/index.html
+++ b/src/index.html
@@ -9,10 +9,15 @@
   <body>
     <div class="glasgow-app">
       <div class="glasgow-bar">
-        Experimental software, use at your own risk.
-        All data is processed locally.
-        Files in /root persist over reloads.
-        <button type="button" id="mountNativeFS">Mount /mnt</button>
+        <div>
+          <p>
+            Experimental software, use at your own risk. All data is processed
+            locally. Files in <code>/root</code> persist over reloads.
+          </p>
+        </div>
+        <div class="glasgow-controls">
+          <button type="button" id="mountNativeFS">Mount /mnt</button>
+        </div>
       </div>
       <div class="glasgow-terminal">
         <div id="terminal">This application requires JavaScript, WebAssembly, JSPI, and WebUSB.</div>

--- a/src/index.html
+++ b/src/index.html
@@ -12,8 +12,7 @@
         Experimental software, use at your own risk.
         All data is processed locally.
         Files in /root persist over reloads.
-        <a href="#" id="mountNativeFS">Mount /mnt</a>
-        <a href="#" id="unmountNativeFS" style="display: none">Unmount /mnt</a>
+        <button type="button" id="mountNativeFS">Mount /mnt</button>
       </div>
       <div class="glasgow-terminal">
         <div id="terminal">This application requires JavaScript, WebAssembly, JSPI, and WebUSB.</div>

--- a/src/index.html
+++ b/src/index.html
@@ -7,14 +7,18 @@
     <link rel="stylesheet" href="app.css">
   </head>
   <body>
-    <div id="bar">
-      Experimental software, use at your own risk.
-      All data is processed locally.
-      Files in /root persist over reloads.
-      <a href="#" id="mountNativeFS">Mount /mnt</a>
-      <a href="#" id="unmountNativeFS" style="display: none">Unmount /mnt</a>
+    <div class="glasgow-app">
+      <div class="glasgow-bar">
+        Experimental software, use at your own risk.
+        All data is processed locally.
+        Files in /root persist over reloads.
+        <a href="#" id="mountNativeFS">Mount /mnt</a>
+        <a href="#" id="unmountNativeFS" style="display: none">Unmount /mnt</a>
+      </div>
+      <div class="glasgow-terminal">
+        <div id="terminal">This application requires JavaScript, WebAssembly, JSPI, and WebUSB.</div>
+      </div>
     </div>
-    <div id="terminal">This application requires JavaScript, WebAssembly, JSPI, and WebUSB.</div>
     <script type="module" src="app.ts"></script>
   </body>
 </html>

--- a/src/reset.css
+++ b/src/reset.css
@@ -1,0 +1,48 @@
+/* http://meyerweb.com/eric/tools/css/reset/
+   v2.0 | 20110126
+   License: none (public domain)
+*/
+
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    font-size: 100%;
+    font: inherit;
+    vertical-align: baseline;
+}
+/* HTML5 display-role reset for older browsers */
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
+    display: block;
+}
+body {
+    line-height: 1;
+}
+ol, ul {
+    list-style: none;
+}
+blockquote, q {
+    quotes: none;
+}
+blockquote:before, blockquote:after,
+q:before, q:after {
+    content: '';
+    content: none;
+}
+table {
+    border-collapse: collapse;
+    border-spacing: 0;
+}


### PR DESCRIPTION
This PR makes a few minor tweaks. Most of it is just some CSS and styling tweaks, with one small accessibility change too:

- Replace FS mount `<a>` with a button. It's generally good practice for accessibility to only use an anchor for navigation, and to instead use a button for interactivity, then using CSS to style as desired. [More context on MDN](https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Accessibility/HTML#onclick_events)
- Add CSS reset
- Rewrite CSS styles around flexbox. This is more of a personal preference thing, but flexbox makes it _much_ easier for me to get the results that I want, and I find it much more intuitive to work with
- Use class names with `glasgow-*` prefix throughout. I noticed that xterm's stylesheet includes quite a few unprefixed names, and felt this was the easiest way to avoid any conflicts
  - We could also refactor to use CSS modules instead (potentially as a follow-up), which should sidestep the issue. Personally though, I've never really been a fan of CSS modules, but this is a pretty compelling use case for them. I'm not really sure how hard it'd be to get working alongside xterm.js's built-in styles though...
- Several small design tweaks (based on what "didn't look quite right" to me):
  - Add padding for xterm
  - Use a grey background for the top bar with off-white sans-serif text to help distinguish it from the terminal content
  - Move the "Mount" button to the end of the top bar (or on its own row for screens narrower than 640px)
  - Disable "Mount" button when selecting a directory
  - Wrap `/root` text in top bar with a `<code>` element, and give it a monospace font

I felt this was a good first pass of minor improvements after sitting down and diving into the code (and wanted to keep it fairly narrow-scoped). I'm open to updating this PR based on feedback too! (As time permits at least-- I'll be pretty busy for the next week, but should be fairly free again after that)

![Screenshot showing a page with a terminal prompt reading "glasgow", and top bar with a label reading the following: "Experimental software, use at your own risk. All data is processed locally. Files in /root persist over reloads." The top bar is grey, and at the end is a button labeled "Mount /mnt".](https://github.com/user-attachments/assets/4115f51a-e011-4953-821f-dadabe26ec77)